### PR TITLE
Block alching with explorer ring, use opacity instead of hiding, right click blacklist/whitelist

### DIFF
--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
@@ -11,24 +11,35 @@ public interface AlchBlockerConfig extends Config
 	String GROUP = "AlchBlocker";
 
 	@ConfigItem(
-			keyName = "itemList",
-			name = "Item List",
-			description = "Configures the list of items to block or unblock from being alched. Format: (item), (item). Example: fire rune, prayer potion*",
-			position = 1
+		keyName = "contextMenuEnabled",
+		name = "Context menu add item",
+		description = "Allow right clicking an item to add to the list.",
+		position = 0
 	)
-	default String itemList()
+	default boolean contextMenuEnabled()
 	{
-		return "*Rune Pouch\n*(1)\n*(2)\n*(3)\n*(4)\n";
+		return true;
 	}
 
 	@ConfigItem(
 		keyName = "listType",
-		name = "List Type",
-		description = "Blacklist will block the items in the list below from being alched.\nWhitelist only allows the items in the list below to be alched .",
-		position = 0
+		name = "List type",
+		description = "Blacklist will block the items in the list below from being alched.\nWhitelist only allows the items in the list below to be alched.",
+		position = 1
 	)
 	default ListType listType()
 	{
 		return ListType.BLACKLIST;
+	}
+
+	@ConfigItem(
+		keyName = "itemList",
+		name = "Item list",
+		description = "Configures the list of items to block or unblock from being alched. Format: (item), (item). Example: fire rune, prayer potion*",
+		position = 2
+	)
+	default String itemList()
+	{
+		return "*Rune Pouch\n*(1)\n*(2)\n*(3)\n*(4)\n";
 	}
 }

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
@@ -1,5 +1,6 @@
 package io.robrichardson.alchblocker;
 
+import io.robrichardson.alchblocker.config.DisplayType;
 import io.robrichardson.alchblocker.config.ListType;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
@@ -22,10 +23,21 @@ public interface AlchBlockerConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "displayType",
+		name = "Display type",
+		description = "How do you want the blacklisted items shown. (explorer ring only supports transparent)",
+		position = 1
+	)
+	default DisplayType displayType()
+	{
+		return DisplayType.TRANSPARENT;
+	}
+
+	@ConfigItem(
 		keyName = "listType",
 		name = "List type",
-		description = "Blacklist will block the items in the list below from being alched.\nWhitelist only allows the items in the list below to be alched.",
-		position = 1
+		description = "Blacklist will block the items in the list below from being alched. Whitelist only allows the items in the list below to be alched.",
+		position = 2
 	)
 	default ListType listType()
 	{
@@ -36,7 +48,7 @@ public interface AlchBlockerConfig extends Config
 		keyName = "itemList",
 		name = "Item list",
 		description = "Configures the list of items to block or unblock from being alched. Format: (item), (item). Example: fire rune, prayer potion*",
-		position = 2
+		position = 3
 	)
 	default String itemList()
 	{

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerConfig.java
@@ -1,5 +1,6 @@
 package io.robrichardson.alchblocker;
 
+import io.robrichardson.alchblocker.config.ListType;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -11,21 +12,23 @@ public interface AlchBlockerConfig extends Config
 
 	@ConfigItem(
 			keyName = "itemList",
-			name = "Items",
-			description = "Configures the list of items to block or unblock from being alched. Format: (item), (item). Example: fire rune, prayer potion*"
+			name = "Item List",
+			description = "Configures the list of items to block or unblock from being alched. Format: (item), (item). Example: fire rune, prayer potion*",
+			position = 1
 	)
 	default String itemList()
 	{
-		return "";
+		return "*Rune Pouch\n*(1)\n*(2)\n*(3)\n*(4)\n";
 	}
 
 	@ConfigItem(
-			keyName = "blacklist",
-			name = "Blacklist",
-			description = "If turned on, it will block the items in the list below. If turned off it only allows the items to be alched in the list below."
+		keyName = "listType",
+		name = "List Type",
+		description = "Blacklist will block the items in the list below from being alched.\nWhitelist only allows the items in the list below to be alched .",
+		position = 0
 	)
-	default boolean blacklist()
+	default ListType listType()
 	{
-		return true;
+		return ListType.BLACKLIST;
 	}
 }

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -163,7 +163,7 @@ public class AlchBlockerPlugin extends Plugin
 
 			if(isBlacklist) {
 				if (config.displayType() == DisplayType.TRANSPARENT || WidgetInfo.EXPLORERS_RING_ALCH_INVENTORY.getId() == inventory.getId()) {
-					inventoryItem.setOpacity(220);
+					inventoryItem.setOpacity(200);
 				} else {
 					inventoryItem.setHidden(true);
 				}

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -101,6 +101,11 @@ public class AlchBlockerPlugin extends Plugin
 	@Subscribe
 	public void onMenuOpened(final MenuOpened event)
 	{
+		// If the user has decided to disable the context menu, no need to process further
+		if (!config.contextMenuEnabled()) {
+			return;
+		}
+
 		final MenuEntry[] entries = event.getMenuEntries();
 		for (int idx = entries.length - 1; idx >= 0; --idx)
 		{

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -1,5 +1,6 @@
 package io.robrichardson.alchblocker;
 
+import io.robrichardson.alchblocker.config.ListType;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -112,8 +113,8 @@ public class AlchBlockerPlugin extends Plugin
 
 					// Item already in block list, no need to add menu item
 					if (
-						(hiddenItems.contains(w.getItemId()) && config.blacklist()) ||
-						(!hiddenItems.contains(w.getItemId()) && !config.blacklist())
+						(hiddenItems.contains(w.getItemId()) && config.listType() == ListType.BLACKLIST) ||
+						(!hiddenItems.contains(w.getItemId()) && config.listType() == ListType.WHITELIST)
 					) {
 						return;
 					}
@@ -121,7 +122,7 @@ public class AlchBlockerPlugin extends Plugin
 					final String itemName = w.getName();
 
 					client.createMenuEntry(idx)
-						.setOption(config.blacklist() ? "Blacklist Alchemy" : "Whitelist Alchemy")
+						.setOption(config.listType() == ListType.BLACKLIST ? "Blacklist Alchemy" : "Whitelist Alchemy")
 						.setTarget(itemName)
 						.setType(MenuAction.RUNELITE)
 						.onClick(e ->
@@ -146,10 +147,10 @@ public class AlchBlockerPlugin extends Plugin
 		for (Widget inventoryItem : Objects.requireNonNull(inventory.getChildren())) {
 			String itemName = Text.removeTags(inventoryItem.getName()).toLowerCase();
 
-			boolean isBlacklist = !config.blacklist();
+			boolean isBlacklist = config.listType() != ListType.BLACKLIST;
 			for(String blockedItem : itemList) {
 				if(WildcardMatcher.matches(blockedItem, itemName)) {
-					isBlacklist = config.blacklist();
+					isBlacklist = config.listType() == ListType.BLACKLIST;
 					break;
 				}
 			}

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -6,13 +6,14 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptPostFired;
+import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
-import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.Text;
@@ -35,9 +36,6 @@ public class AlchBlockerPlugin extends Plugin
 
 	@Inject
 	private AlchBlockerConfig config;
-
-	@Inject
-	private ItemManager itemManager;
 
 	Set<String> itemList = new HashSet<>();
 	Set<Integer> hiddenItems = new HashSet<>();
@@ -70,7 +68,11 @@ public class AlchBlockerPlugin extends Plugin
 	@Subscribe()
 	public void onMenuOptionClicked(MenuOptionClicked event) {
 		String menuTarget = Text.removeTags(event.getMenuTarget());
-		isAlching = Objects.equals(event.getMenuOption(), "Cast") && (Objects.equals(menuTarget, "High Level Alchemy") || Objects.equals(menuTarget, "Low Level Alchemy"));
+		isAlching = event.getMenuOption().contains("Alchemy") || (event.getMenuOption().equals("Cast") && menuTarget.contains("Level Alchemy"));
+		// If item in our list of blocked items, don't allow the action
+		if (isAlching && hiddenItems.contains(event.getItemId())) {
+			event.consume();
+		}
 		if(!isAlching) {
 			showBlockedItems();
 		}
@@ -83,25 +85,35 @@ public class AlchBlockerPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	private void onWidgetLoaded(WidgetLoaded event) {
+		if (event.getGroupId() == WidgetID.EXPLORERS_RING_ALCH_GROUP_ID) {
+			hideBlockedItems();
+		}
+	}
+
 	private void hideBlockedItems() {
-		Widget inventory = client.getWidget(WidgetInfo.INVENTORY);
+		Widget inventory = client.getWidget(WidgetInfo.EXPLORERS_RING_ALCH_INVENTORY);
 		if (inventory == null) {
-			return;
+			inventory = client.getWidget(WidgetInfo.INVENTORY);
+			if (inventory == null) {
+				return;
+			}
 		}
 
 		for (Widget inventoryItem : Objects.requireNonNull(inventory.getChildren())) {
 			String itemName = Text.removeTags(inventoryItem.getName()).toLowerCase();
 
-			boolean shouldHide = !config.blacklist();
+			boolean isBlacklist = !config.blacklist();
 			for(String blockedItem : itemList) {
 				if(WildcardMatcher.matches(blockedItem, itemName)) {
-					shouldHide = config.blacklist();
+					isBlacklist = config.blacklist();
 					break;
 				}
 			}
 
-			if(shouldHide) {
-				inventoryItem.setHidden(true);
+			if(isBlacklist) {
+				inventoryItem.setOpacity(220);
 				hiddenItems.add(inventoryItem.getItemId());
 			}
 		}
@@ -112,14 +124,19 @@ public class AlchBlockerPlugin extends Plugin
 			return;
 		}
 
-		Widget inventory = client.getWidget(WidgetInfo.INVENTORY);
+		Widget inventory = client.getWidget(WidgetInfo.EXPLORERS_RING_ALCH_INVENTORY);
+		if (inventory != null) {
+			// We don't need to show items again if we are in the explorer ring widget
+			return;
+		}
+		inventory = client.getWidget(WidgetInfo.INVENTORY);
 		if (inventory == null) {
 			return;
 		}
 
 		for (Widget inventoryItem : Objects.requireNonNull(inventory.getChildren())) {
 			if(hiddenItems.contains(inventoryItem.getItemId())) {
-				inventoryItem.setHidden(false);
+				inventoryItem.setOpacity(0);
 			}
 		}
 

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -1,6 +1,7 @@
 package io.robrichardson.alchblocker;
 
 import io.robrichardson.alchblocker.config.ListType;
+import io.robrichardson.alchblocker.config.DisplayType;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -161,7 +162,11 @@ public class AlchBlockerPlugin extends Plugin
 			}
 
 			if(isBlacklist) {
-				inventoryItem.setOpacity(220);
+				if (config.displayType() == DisplayType.TRANSPARENT || WidgetInfo.EXPLORERS_RING_ALCH_INVENTORY.getId() == inventory.getId()) {
+					inventoryItem.setOpacity(220);
+				} else {
+					inventoryItem.setHidden(true);
+				}
 				hiddenItems.add(inventoryItem.getItemId());
 			}
 		}
@@ -182,7 +187,11 @@ public class AlchBlockerPlugin extends Plugin
 
 		for (Widget inventoryItem : Objects.requireNonNull(inventory.getChildren())) {
 			if(hiddenItems.contains(inventoryItem.getItemId())) {
-				inventoryItem.setOpacity(0);
+				if (config.displayType() == DisplayType.TRANSPARENT || WidgetInfo.EXPLORERS_RING_ALCH_INVENTORY.getId() == inventory.getId()) {
+					inventoryItem.setOpacity(0);
+				} else {
+					inventoryItem.setHidden(false);
+				}
 			}
 		}
 

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -65,6 +65,7 @@ public class AlchBlockerPlugin extends Plugin
 		if (!AlchBlockerConfig.GROUP.equals(event.getGroup())) return;
 		itemList = convertToListToSet();
 		if(isAlching) {
+			clientThread.invoke(this::showBlockedItems);
 			clientThread.invoke(this::hideBlockedItems);
 		}
 	}

--- a/src/main/java/io/robrichardson/alchblocker/config/DisplayType.java
+++ b/src/main/java/io/robrichardson/alchblocker/config/DisplayType.java
@@ -1,0 +1,6 @@
+package io.robrichardson.alchblocker.config;
+
+public enum DisplayType {
+    TRANSPARENT,
+    HIDDEN
+}

--- a/src/main/java/io/robrichardson/alchblocker/config/ListType.java
+++ b/src/main/java/io/robrichardson/alchblocker/config/ListType.java
@@ -1,0 +1,6 @@
+package io.robrichardson.alchblocker.config;
+
+public enum ListType {
+    BLACKLIST,
+    WHITELIST
+}


### PR DESCRIPTION
This PR blocks alching items on the block list while using an explorers ring.

![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/0b6facd2-3fae-4879-9d19-58247906f2e0)

Adds a menu option to quickly add items to the blacklist/whitelist:
![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/5b98c4cf-2d23-451b-b37d-82e7a96c653f)
![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/f4118bf2-69df-47d9-b944-1b50a8c6e4e1)


Also changes to use opacity instead of fully hiding the items.
(hiding wasn't always working in the explorer ring interface, was going to make it optional to hide or make transparent)

![image](https://github.com/robrichardson13/alch-blocker/assets/7288322/7d84ffd2-64dc-4a85-81fd-d63679c30e08)

GIF:
![AlchProtect](https://github.com/robrichardson13/alch-blocker/assets/7288322/eea46bae-1110-47da-a1b4-6fc30c322c0a)

closes #3