### PR TITLE
fix alchs staying filtered when you alch an item

### DIFF
--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -1,11 +1,21 @@
 package io.robrichardson.alchblocker;
 
-import io.robrichardson.alchblocker.config.ListType;
-import io.robrichardson.alchblocker.config.DisplayType;
-import com.google.inject.Provides;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
+
+import com.google.inject.Provides;
+
+import io.robrichardson.alchblocker.config.DisplayType;
+import io.robrichardson.alchblocker.config.ListType;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.ScriptID;
 import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ScriptPostFired;
@@ -21,9 +31,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.util.Text;
 import net.runelite.client.util.WildcardMatcher;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @PluginDescriptor(
@@ -75,7 +82,7 @@ public class AlchBlockerPlugin extends Plugin
 	@Subscribe()
 	public void onMenuOptionClicked(MenuOptionClicked event) {
 		String menuTarget = Text.removeTags(event.getMenuTarget());
-		isAlching = event.getMenuOption().contains("Alchemy") || (event.getMenuOption().equals("Cast") && menuTarget.contains("Level Alchemy"));
+		isAlching = event.getMenuOption().contains("Alchemy") || (event.getMenuOption().equals("Cast") && (Objects.equals(menuTarget, "High Level Alchemy") || Objects.equals(menuTarget, "Low Level Alchemy")));
 		// If item in our list of blocked items, don't allow the action
 		if (isAlching && hiddenItems.contains(event.getItemId())) {
 			event.consume();


### PR DESCRIPTION
This fixes #12. Tagging @RedSparr0w as the person who introduced this bug in case my fix breaks something else I'm not aware of.

After #11, the inventory would remain filtered after alching an item until another click was provided. This was convenient visually if you were spam-alching, but it was annoying for the reasons specified in #12 - namely, alching an item then using Fkeys to get back to the inventory left things filtered.

This was because after switching to `.contains`, the second half of the alch action (selecting an item) was also captured as "still alching". Reverting this part of the logic for determining when you're alching resolves the issue.

The first screenshot captures what `isAlching` captured before #11 and will capture again once this PR is merged.
The second shows the part of the process that should not be captured that #11 added into the equation.

![Screenshot 2023-11-13 164229](https://github.com/robrichardson13/alch-blocker/assets/23144957/f7cd93f7-94f4-42df-aa55-bde0aac1bc6a)
![Screenshot 2023-11-13 164220](https://github.com/robrichardson13/alch-blocker/assets/23144957/f74a276b-a9ab-47f9-b8d6-c6cf56678504)

Tested with explorer's ring and normal high alchemy to make sure nothing broke, worked for me. Found a couple new bugs I'll file issues for (related to explorer's ring, weird edge cases that should rarely if ever affect anyone). But tested on base RuneLite and those were not introduced by this PR.

(edit: import changes were automatically done by my vscode config, couldn't figure out how to disable it but figured it wasn't a problem. if it is, can tweak that upon request)