### PR TITLE
separate out two types of alch actions; fix transparent item alch blocking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'io.robrichardson.alchblocker'
-version = '1.4'
+version = '1.5'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -84,7 +84,7 @@ public class AlchBlockerPlugin extends Plugin
 		String menuTarget = Text.removeTags(event.getMenuTarget());
 		// did you just click an alchemy spell (and thus need to have items in inventory hidden)
 		isAlching = event.getMenuOption().equals("Cast") && (Objects.equals(menuTarget, "High Level Alchemy") || Objects.equals(menuTarget, "Low Level Alchemy"));
-		// did you just click an item to try to alch it ("High-Alchemy <item>" from explorer's ring, "Cast High Level Alchemy -> <item>"
+		// did you just click an item to try to alch it ("High-Alchemy <item>" from explorer's ring, "Cast High Level Alchemy -> <item>" from spell)
 		boolean tryingToAlch = event.getMenuOption().contains("-Alchemy") || (event.getMenuOption().equals("Cast") && menuTarget.contains("Alchemy ->"));
 		if (tryingToAlch && hiddenItems.contains(event.getItemId())) {
 			event.consume();

--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -82,12 +82,14 @@ public class AlchBlockerPlugin extends Plugin
 	@Subscribe()
 	public void onMenuOptionClicked(MenuOptionClicked event) {
 		String menuTarget = Text.removeTags(event.getMenuTarget());
-		isAlching = event.getMenuOption().contains("Alchemy") || (event.getMenuOption().equals("Cast") && (Objects.equals(menuTarget, "High Level Alchemy") || Objects.equals(menuTarget, "Low Level Alchemy")));
-		// If item in our list of blocked items, don't allow the action
-		if (isAlching && hiddenItems.contains(event.getItemId())) {
+		// did you just click an alchemy spell (and thus need to have items in inventory hidden)
+		isAlching = event.getMenuOption().equals("Cast") && (Objects.equals(menuTarget, "High Level Alchemy") || Objects.equals(menuTarget, "Low Level Alchemy"));
+		// did you just click an item to try to alch it ("High-Alchemy <item>" from explorer's ring, "Cast High Level Alchemy -> <item>"
+		boolean tryingToAlch = event.getMenuOption().contains("-Alchemy") || (event.getMenuOption().equals("Cast") && menuTarget.contains("Alchemy ->"));
+		if (tryingToAlch && hiddenItems.contains(event.getItemId())) {
 			event.consume();
 		}
-		if(!isAlching) {
+		else if(!isAlching) {
 			showBlockedItems();
 		}
 	}


### PR DESCRIPTION
fixes #19 

my previous PR #13 tried to fix a small bug but failed to understand how these variables were used across the plugin
it was tested with the explorer's ring and with normal alchemy in "hidden" mode, but it was not tested with normal alchemy in "transparent" mode. this PR has been tested in all three modes and behaves as expected (items hide/show correctly, transparent items cannot be alched, and clicking on no item clears the alchemy cast) - for both Low Alchemy and High Alchemy.

I don't have an account that only has an explorer's ring 1/2/3, so I can't strictly test that those are correctly captured. But assuming they follow the convention of the action being "Low-Alchemy" compared to the "High-Alchemy" convention of the explorer's ring 4, this should work for that too.

sorry @robrichardson13 for the issues with the previous PR... hoping this is the last one on this topic. comments added to variables to try to differentiate what they're saying, 