### PR TITLE
Fork/eckersleyful/master - Correct alch IDs after minigame teleport moved them by one

### DIFF
--- a/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
+++ b/src/main/java/io/robrichardson/alchblocker/AlchBlockerPlugin.java
@@ -61,8 +61,10 @@ public class AlchBlockerPlugin extends Plugin
 	Set<Integer> hiddenItems = new HashSet<>();
 
 	// Widget IDs for alchemy spells (from InterfaceID.MagicSpellbook)
-	private static final int HIGH_ALCHEMY_WIDGET_ID = 0x00da_002c;
-	private static final int LOW_ALCHEMY_WIDGET_ID = 0x00da_0015;
+	// This really should be grabbed dynamically...
+	// Updated the hardcoded IDs to account for the minigame teleport spell addition
+	private static final int HIGH_ALCHEMY_WIDGET_ID = 0x00da_002d; // was 0x00da_002c
+	private static final int LOW_ALCHEMY_WIDGET_ID  = 0x00da_0016; // was 0x00da_0015
 
 	@Override
 	protected void startUp() throws Exception {


### PR DESCRIPTION
This PR updates the hardcoded High and Low Alchemy widget IDs in AlchBlockerPlugin.java to match the latest RuneLite client, following the addition of the minigame teleport spell which shifted the child indices by +1.

High Alchemy: 0x00da_002d (was 0x00da_002c)

Low Alchemy: 0x00da_0016 (was 0x00da_0015)

Widget IDs were grabbed using the Widget Inspector in RuneLite’s developer tools.